### PR TITLE
[WIP]画像複数枚機能・プレビュー機能

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -1,35 +1,33 @@
 $(function(){
-  //画像のプレビュー表示
-  var file_field = document.querySelector('input[type=file]')
-  $('.hidden').change(function(){
-   var file = $('input[type="file"]').prop('files')[0];
-   var fileReader = new FileReader();
-
-   fileReader.onloadend = function() {
-     var src = fileReader.result
-     var html= `<img src="${src}">`
-     $('#image-box__container').before(html);
-   }
-   fileReader.readAsDataURL(file);
-  });
-
-//画像の複数枚投稿
   const buildFileField = (index)=> {
     const html = `<div data-index="${index}" class="js-file_group">
+                    <label class="image_box-icon" for="item_pictures_attributes_${index}_image">
+                    <i class='fa fa-camera likeIcon'></i>
                     <input class="hidden" type="file"
                     name="item[pictures_attributes][${index}][image]"
-                    id="item_pictures_attributes_${index}_image">
-                  </div>`;
+                    id="item_pictures_attributes_${index}_image"></div>`;
+    return html;
+  }
+
+  const buildImg = (index, url)=> {
+    const html = `<img data-index="${index}" src="${url}">`;
     return html;
   }
 
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
 
   $('#image-box__container').on('change', '.hidden', function(e) {
+    const targetIndex = $(this).parent().data('index');
+    const file = e.target.files[0];
+    const blobUrl = window.URL.createObjectURL(file);
+    $('#image-box__container').before(buildImg(targetIndex, blobUrl));
+
     $('#image-box__container').append(buildFileField(fileIndex[0]));
     fileIndex.shift();
     fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
   });
+
+
 
   $('#image-box__container').on('click', '.js-remove', function() {
     $(this).parent().remove();

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,6 @@ class Item < ApplicationRecord
   validates :item_name, presence: true, length: {maximum: 40}
   validates :discription, presence: true, length: {maximum: 1000}
 
-
   validates_associated :pictures
   validates :pictures, presence: true
   


### PR DESCRIPTION
# what
・画像複数枚投稿
・プレビュー表示コード変更
 item.jsの編集

# why
画像複数枚できなくなっていたので修正。
複数枚投稿を修正すると、プレビュー機能ができなかったので
コードを修正したため
